### PR TITLE
Fixing README for sending SMS messages example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ import (
 func main() {
   client := twilio.NewClient("<ACCOUNT_SID", "<AUTH_TOKEN>")
 
-  message, err := twilio.SendMessage(client, "3334445555", "2223334444", Body("Hello World!"))
+  message, err := twilio.NewMessage(client, "3334445555", "2223334444", Body("Hello World!"))
 
   if err != nil {
     fmt.Println(err)
   } else {
-    fmt.Println("Message sent!")
+    fmt.Println(message.Status)
   }
 }
 ```


### PR DESCRIPTION
`SendMessage` doens't exist!  You also need to use `message` after setting it.
