### PR TITLE
Adding *http.Client parameter to NewClient()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-  client := twilio.NewClient("<ACCOUNT_SID", "<AUTH_TOKEN>")
+  client := twilio.NewClient("<ACCOUNT_SID", "<AUTH_TOKEN>", nil)
 
   message, err := twilio.NewMessage(client, "3334445555", "2223334444", twilio.Body("Hello World!"))
 
@@ -48,7 +48,7 @@ import (
 )
 
 func main() {
-  client := twilio.NewClient("<ACCOUNT_SID>", "<AUTH_TOKEN>")
+  client := twilio.NewClient("<ACCOUNT_SID>", "<AUTH_TOKEN>", nil)
 
   call, err := twilio.NewCall(client, "8883332222", "3334443333", nil)
 

--- a/call_integration_test.go
+++ b/call_integration_test.go
@@ -1,14 +1,15 @@
 package twiliogo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIntegrationCallList(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	callList, err := GetCallList(client)
 
@@ -22,7 +23,7 @@ func TestIntegrationCallList(t *testing.T) {
 func TestIntegrationMakingCall(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(TEST_KEY, TEST_TOKEN)
+	client := NewClient(TEST_KEY, TEST_TOKEN, nil)
 
 	call, err := NewCall(client, TEST_FROM_NUMBER, TO_NUMBER, Callback("http://test.com"))
 
@@ -34,7 +35,7 @@ func TestIntegrationMakingCall(t *testing.T) {
 func TestIntegrationCallListNextPage(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	callList, err := GetCallList(client)
 
@@ -50,7 +51,7 @@ func TestIntegrationCallListNextPage(t *testing.T) {
 func TestIntegrationGetCall(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	callList, err := GetCallList(client)
 

--- a/message_integration_test.go
+++ b/message_integration_test.go
@@ -1,14 +1,15 @@
 package twiliogo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIntegrationMessageList(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	messageList, err := GetMessageList(client)
 
@@ -22,7 +23,7 @@ func TestIntegrationSendSMS(t *testing.T) {
 	/* /Messages endpoint is currently not recognized by Test Credentials */
 	/* CheckTestEnv(t) */
 
-	/* client := NewClient(TEST_KEY, TEST_TOKEN) */
+	/* client := NewClient(TEST_KEY, TEST_TOKEN, nil) */
 
 	/* message, err := NewMessage(client, TEST_FROM_NUMBER, TO_NUMBER, Body("Test Message")) */
 
@@ -35,7 +36,7 @@ func TestIntegrationSendSMS(t *testing.T) {
 func TestIntegrationMessageListNextPage(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	messageList, err := GetMessageList(client)
 
@@ -51,7 +52,7 @@ func TestIntegrationMessageListNextPage(t *testing.T) {
 func TestIntegrationGetMessage(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewClient(API_KEY, API_TOKEN, nil)
 
 	messageList, err := GetMessageList(client)
 


### PR DESCRIPTION
In order to use the client behind a proxy or some other more complex scenario (like Google AppEngine), control over the *http.Client used for the requests is required. 

This breaks the api, but it's an easy fix since it's just adding a single nil parameter at the end. If nil is passed, &http.Client{} is used.