### PR TITLE
Add IP Messaging methods to client

### DIFF
--- a/call.go
+++ b/call.go
@@ -42,7 +42,7 @@ func NewCall(client Client, from, to string, callback Optional, optionals ...Opt
 		params.Set(param, value)
 	}
 
-	res, err := client.post(params, client.RootUrl()+"/Calls.json")
+	res, err := client.post(params, "/Calls.json")
 
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func NewCall(client Client, from, to string, callback Optional, optionals ...Opt
 func GetCall(client Client, sid string) (*Call, error) {
 	var call *Call
 
-	res, err := client.get(url.Values{}, client.RootUrl()+"/Calls/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Calls/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (call *Call) Update(client Client, optionals ...Optional) error {
 		params.Set(param, value)
 	}
 
-	res, err := client.post(params, client.RootUrl()+"/Calls/"+call.Sid+".json")
+	res, err := client.post(params, "/Calls/"+call.Sid+".json")
 
 	if err != nil {
 		return err

--- a/call_list.go
+++ b/call_list.go
@@ -31,7 +31,7 @@ func GetCallList(client Client, optionals ...Optional) (*CallList, error) {
 		params.Set(param, value)
 	}
 
-	body, err := client.get(nil, client.RootUrl()+"/Calls.json")
+	body, err := client.get(nil, "/Calls.json")
 
 	if err != nil {
 		return nil, err

--- a/call_test.go
+++ b/call_test.go
@@ -2,9 +2,10 @@ package twiliogo
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testCall = Call{
@@ -39,7 +40,7 @@ func TestNewCall(t *testing.T) {
 	params.Set("To", "5555555555")
 	params.Set("Url", "http://callback.com")
 
-	client.On("post", params, client.RootUrl()+"/Calls.json").Return(callJson, nil)
+	client.On("post", params, "/Calls.json").Return(callJson, nil)
 
 	call, err := NewCall(client, "6666666666", "5555555555", Callback("http://callback.com"))
 
@@ -55,7 +56,7 @@ func TestGetCall(t *testing.T) {
 
 	callJson, _ := json.Marshal(testCall)
 
-	client.On("get", url.Values{}, client.RootUrl()+"/Calls/testsid.json").Return(callJson, nil)
+	client.On("get", url.Values{}, "/Calls/testsid.json").Return(callJson, nil)
 
 	call, err := GetCall(client, "testsid")
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package twiliogo
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -10,6 +11,9 @@ import (
 
 const ROOT = "https://api.twilio.com"
 const VERSION = "2010-04-01"
+const IP_MESSAGING_ROOT = "https://ip-messaging.twilio.com"
+const IP_MESSAGING_VERSION = "v1"
+const IP_MESSAGING_ROOT_URL = IP_MESSAGING_ROOT + "/" + IP_MESSAGING_VERSION
 
 type Client interface {
 	AccountSid() string
@@ -17,6 +21,9 @@ type Client interface {
 	RootUrl() string
 	get(url.Values, string) ([]byte, error)
 	post(url.Values, string) ([]byte, error)
+	getIP(url.Values, string) ([]byte, error)
+	postIP(url.Values, string) ([]byte, error)
+	deleteIP(string) error
 }
 
 type TwilioClient struct {
@@ -31,7 +38,51 @@ func NewClient(accountSid, authToken string) *TwilioClient {
 }
 
 func (client *TwilioClient) post(values url.Values, uri string) ([]byte, error) {
-	req, err := http.NewRequest("POST", ROOT+uri, strings.NewReader(values.Encode()))
+	if !strings.HasPrefix(uri, "http") {
+		uri = ROOT + uri
+	}
+	req, err := http.NewRequest("POST", uri, strings.NewReader(values.Encode()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(client.AccountSid(), client.AuthToken())
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	httpClient := &http.Client{}
+
+	res, err := httpClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return body, err
+	}
+
+	if res.StatusCode != 200 && res.StatusCode != 201 {
+		if res.StatusCode == 500 {
+			return body, Error{"Server Error"}
+		} else {
+			twilioError := new(TwilioError)
+			json.Unmarshal(body, twilioError)
+			return body, twilioError
+		}
+	}
+
+	return body, err
+}
+
+func (client *TwilioClient) postIP(values url.Values, uri string) ([]byte, error) {
+	if !strings.HasPrefix(uri, "http") {
+		uri = IP_MESSAGING_ROOT_URL + uri
+	}
+	req, err := http.NewRequest("POST", uri, strings.NewReader(values.Encode()))
 
 	if err != nil {
 		return nil, err
@@ -69,6 +120,9 @@ func (client *TwilioClient) post(values url.Values, uri string) ([]byte, error) 
 }
 
 func (client *TwilioClient) get(queryParams url.Values, uri string) ([]byte, error) {
+	if !strings.HasPrefix(uri, "http") {
+		uri = ROOT + uri
+	}
 	var params *strings.Reader
 
 	if queryParams == nil {
@@ -76,7 +130,7 @@ func (client *TwilioClient) get(queryParams url.Values, uri string) ([]byte, err
 	}
 
 	params = strings.NewReader(queryParams.Encode())
-	req, err := http.NewRequest("GET", ROOT+uri, params)
+	req, err := http.NewRequest("GET", uri, params)
 
 	if err != nil {
 		return nil, err
@@ -110,6 +164,81 @@ func (client *TwilioClient) get(queryParams url.Values, uri string) ([]byte, err
 	}
 
 	return body, err
+}
+
+func (client *TwilioClient) getIP(queryParams url.Values, uri string) ([]byte, error) {
+	if !strings.HasPrefix(uri, "http") {
+		uri = IP_MESSAGING_ROOT_URL + uri
+	}
+	var params *strings.Reader
+
+	if queryParams == nil {
+		queryParams = url.Values{}
+	}
+
+	params = strings.NewReader(queryParams.Encode())
+	req, err := http.NewRequest("GET", uri, params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(client.AccountSid(), client.AuthToken())
+	httpClient := &http.Client{}
+
+	res, err := httpClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return body, err
+	}
+
+	if res.StatusCode != 200 && res.StatusCode != 201 {
+		if res.StatusCode == 500 {
+			return body, Error{"Server Error"}
+		} else {
+			twilioError := new(TwilioError)
+			json.Unmarshal(body, twilioError)
+			return body, twilioError
+		}
+	}
+
+	return body, err
+}
+
+func (client *TwilioClient) deleteIP(uri string) error {
+	if !strings.HasPrefix(uri, "http") {
+		uri = IP_MESSAGING_ROOT_URL + uri
+	}
+	req, err := http.NewRequest("DELETE", uri, nil)
+
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(client.AccountSid(), client.AuthToken())
+	httpClient := &http.Client{}
+
+	res, err := httpClient.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 204 {
+		return fmt.Errorf("Non-204 returned from server for DELETE: %d", res.StatusCode)
+	}
+
+	return nil
 }
 
 func (client *TwilioClient) AccountSid() string {

--- a/helper_test.go
+++ b/helper_test.go
@@ -23,3 +23,11 @@ func CheckTestEnv(t *testing.T) {
 		t.SkipNow()
 	}
 }
+
+func TestBuildUri(t *testing.T) {
+	c := NewClient("abc", "")
+	uri := c.buildUri("qzx")
+	if uri != ROOT+"/"+VERSION+"/Accounts/abc/qzx" {
+		t.Errorf("buildUri failed: got %s", uri)
+	}
+}

--- a/incoming_phone_number.go
+++ b/incoming_phone_number.go
@@ -39,7 +39,7 @@ type IncomingPhoneNumber struct {
 func GetIncomingPhoneNumber(client Client, sid string) (*IncomingPhoneNumber, error) {
 	var incomingPhoneNumber *IncomingPhoneNumber
 
-	res, err := client.get(url.Values{}, client.RootUrl()+"/IncomingPhoneNumbers/"+sid+".json")
+	res, err := client.get(url.Values{}, "/IncomingPhoneNumbers/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func BuyPhoneNumber(client Client, number Optional) (*IncomingPhoneNumber, error
 	param, value := number.GetParam()
 	params.Set(param, value)
 
-	res, err := client.post(params, client.RootUrl()+"/IncomingPhoneNumbers.json")
+	res, err := client.post(params, "/IncomingPhoneNumbers.json")
 
 	if err != nil {
 		return incomingPhoneNumber, err

--- a/incoming_phone_number_list.go
+++ b/incoming_phone_number_list.go
@@ -31,7 +31,7 @@ func GetIncomingPhoneNumberList(client Client, optionals ...Optional) (*Incoming
 		params.Set(param, value)
 	}
 
-	body, err := client.get(params, client.RootUrl()+"/IncomingPhoneNumbers.json")
+	body, err := client.get(params, "/IncomingPhoneNumbers.json")
 
 	if err != nil {
 		return nil, err

--- a/incoming_phone_number_test.go
+++ b/incoming_phone_number_test.go
@@ -37,7 +37,7 @@ func TestBuyPhoneNumber(t *testing.T) {
 	params := url.Values{}
 	params.Set("PhoneNumber", "4444444444")
 
-	client.On("post", params, client.RootUrl()+"/IncomingPhoneNumbers.json").Return(numberJson, nil)
+	client.On("post", params, "/IncomingPhoneNumbers.json").Return(numberJson, nil)
 
 	number, err := BuyPhoneNumber(client, PhoneNumber("4444444444"))
 
@@ -53,7 +53,7 @@ func TestGetIncomingPhoneNumber(t *testing.T) {
 
 	numberJson, _ := json.Marshal(testNumber)
 
-	client.On("get", url.Values{}, client.RootUrl()+"/IncomingPhoneNumbers/testsid.json").Return(numberJson, nil)
+	client.On("get", url.Values{}, "/IncomingPhoneNumbers/testsid.json").Return(numberJson, nil)
 
 	number, err := GetIncomingPhoneNumber(client, "testsid")
 

--- a/ip_channel.go
+++ b/ip_channel.go
@@ -1,0 +1,197 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPChannel is a IP Messaging Channel resource.
+type IPChannel struct {
+	Sid          string            `json:"sid"`
+	AccountSid   string            `json:"account_sid"`
+	ServiceSid   string            `json:"service_sid"`
+	FriendlyName string            `json:"friendly_name"`
+	UniqueName   string            `json:"unique_name"`
+	Attributes   string            `json:"attributes"`
+	Type         string            `json:"type"`
+	DateCreated  string            `json:"date_created"`
+	DateUpdated  string            `json:"date_updated"`
+	CreatedBy    string            `json:"created_by"`
+	URL          string            `json:"url"`
+	Links        map[string]string `json:"links"`
+}
+
+// IPChannelList gives the results for querying the set of channels. Returns the first page
+// by default.
+type IPChannelList struct {
+	Client   Client
+	Channels []IPChannel `json:"channels"`
+	Meta     Meta        `json:"meta"`
+}
+
+// NewIPChannel creates a new IP Messaging Channel.
+func NewIPChannel(client Client, serviceSid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
+	var channel *IPChannel
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("UniqueName", uniqueName)
+	kind := "private"
+	if public {
+		kind = "public"
+	}
+	params.Set("Type", kind)
+	params.Set("Attributes", attributes)
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels.json")
+
+	if err != nil {
+		return channel, err
+	}
+
+	channel = new(IPChannel)
+	err = json.Unmarshal(res, channel)
+
+	return channel, err
+}
+
+// UpdateIPChannel updates ane existing IP Messaging Channel.
+func UpdateIPChannel(client Client, serviceSid string, sid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
+	var channel *IPChannel
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("UniqueName", uniqueName)
+	kind := "private"
+	if public {
+		kind = "public"
+	}
+	params.Set("Type", kind)
+	params.Set("Attributes", attributes)
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+sid+".json")
+
+	if err != nil {
+		return channel, err
+	}
+
+	channel = new(IPChannel)
+	err = json.Unmarshal(res, channel)
+
+	return channel, err
+}
+
+// GetIPChannel returns the specified IP Channel.
+func GetIPChannel(client Client, serviceSid string, sid string) (*IPChannel, error) {
+	var channel *IPChannel
+
+	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	channel = new(IPChannel)
+	err = json.Unmarshal(res, channel)
+
+	return channel, err
+}
+
+// DeleteIPChannel deletes the given IP Channel.
+func DeleteIPChannel(client Client, serviceSid, sid string) error {
+	return client.deleteIP("/Services/" + serviceSid + "/Channels/" + sid)
+}
+
+// ListIPChannels returns the first page of channels.
+func ListIPChannels(client Client, serviceSid string) (*IPChannelList, error) {
+	var channelList *IPChannelList
+
+	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels.json")
+
+	if err != nil {
+		return channelList, err
+	}
+
+	channelList = new(IPChannelList)
+	channelList.Client = client
+	err = json.Unmarshal(body, channelList)
+
+	return channelList, err
+}
+
+// GetChannels recturns the current page of channels.
+func (c *IPChannelList) GetChannels() []IPChannel {
+	return c.Channels
+}
+
+// GetAllChannels returns all of the channels from all of the pages (from here forward).
+func (c *IPChannelList) GetAllChannels() ([]IPChannel, error) {
+	channels := c.Channels
+	t := c
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		channels = append(channels, t.Channels...)
+	}
+	return channels, nil
+}
+
+// HasNextPage returns whether or not there is a next page of channels.
+func (c *IPChannelList) HasNextPage() bool {
+	return c.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of channels.
+func (c *IPChannelList) NextPage() (*IPChannelList, error) {
+	if !c.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (c *IPChannelList) HasPreviousPage() bool {
+	return c.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of channels.
+func (c *IPChannelList) PreviousPage() (*IPChannelList, error) {
+	if !c.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of channels.
+func (c *IPChannelList) FirstPage() (*IPChannelList, error) {
+	return c.getPage(c.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of channels.
+func (c *IPChannelList) LastPage() (*IPChannelList, error) {
+	return c.getPage(c.Meta.LastPageUri)
+}
+
+func (c *IPChannelList) getPage(uri string) (*IPChannelList, error) {
+	var channelList *IPChannelList
+
+	client := c.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return channelList, err
+	}
+
+	channelList = new(IPChannelList)
+	channelList.Client = client
+	err = json.Unmarshal(body, channelList)
+
+	return channelList, err
+}

--- a/ip_channel.go
+++ b/ip_channel.go
@@ -30,7 +30,7 @@ type IPChannelList struct {
 }
 
 // NewIPChannel creates a new IP Messaging Channel.
-func NewIPChannel(client Client, serviceSid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
+func NewIPChannel(client *TwilioIPMessagingClient, serviceSid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
 	var channel *IPChannel
 
 	params := url.Values{}
@@ -43,7 +43,7 @@ func NewIPChannel(client Client, serviceSid string, friendlyName string, uniqueN
 	params.Set("Type", kind)
 	params.Set("Attributes", attributes)
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels.json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Channels.json")
 
 	if err != nil {
 		return channel, err
@@ -56,7 +56,7 @@ func NewIPChannel(client Client, serviceSid string, friendlyName string, uniqueN
 }
 
 // UpdateIPChannel updates ane existing IP Messaging Channel.
-func UpdateIPChannel(client Client, serviceSid string, sid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
+func UpdateIPChannel(client *TwilioIPMessagingClient, serviceSid string, sid string, friendlyName string, uniqueName string, public bool, attributes string) (*IPChannel, error) {
 	var channel *IPChannel
 
 	params := url.Values{}
@@ -69,7 +69,7 @@ func UpdateIPChannel(client Client, serviceSid string, sid string, friendlyName 
 	params.Set("Type", kind)
 	params.Set("Attributes", attributes)
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+sid+".json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Channels/"+sid+".json")
 
 	if err != nil {
 		return channel, err
@@ -82,10 +82,10 @@ func UpdateIPChannel(client Client, serviceSid string, sid string, friendlyName 
 }
 
 // GetIPChannel returns the specified IP Channel.
-func GetIPChannel(client Client, serviceSid string, sid string) (*IPChannel, error) {
+func GetIPChannel(client *TwilioIPMessagingClient, serviceSid string, sid string) (*IPChannel, error) {
 	var channel *IPChannel
 
-	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+serviceSid+"/Channels/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -98,15 +98,15 @@ func GetIPChannel(client Client, serviceSid string, sid string) (*IPChannel, err
 }
 
 // DeleteIPChannel deletes the given IP Channel.
-func DeleteIPChannel(client Client, serviceSid, sid string) error {
-	return client.deleteIP("/Services/" + serviceSid + "/Channels/" + sid)
+func DeleteIPChannel(client *TwilioIPMessagingClient, serviceSid, sid string) error {
+	return client.delete("/Services/" + serviceSid + "/Channels/" + sid)
 }
 
 // ListIPChannels returns the first page of channels.
-func ListIPChannels(client Client, serviceSid string) (*IPChannelList, error) {
+func ListIPChannels(client *TwilioIPMessagingClient, serviceSid string) (*IPChannelList, error) {
 	var channelList *IPChannelList
 
-	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels.json")
+	body, err := client.get(nil, "/Services/"+serviceSid+"/Channels.json")
 
 	if err != nil {
 		return channelList, err
@@ -183,7 +183,7 @@ func (c *IPChannelList) getPage(uri string) (*IPChannelList, error) {
 
 	client := c.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return channelList, err

--- a/ip_client.go
+++ b/ip_client.go
@@ -1,0 +1,21 @@
+package twiliogo
+
+// Constants for the IP Messaging service.
+const (
+	IP_MESSAGING_ROOT     = "https://ip-messaging.twilio.com"
+	IP_MESSAGING_VERSION  = "v1"
+	IP_MESSAGING_ROOT_URL = IP_MESSAGING_ROOT + "/" + IP_MESSAGING_VERSION
+)
+
+// TwilioIPMessagingClient is used for accessing the Twilio IP Messaging API.
+type TwilioIPMessagingClient struct {
+	TwilioClient
+}
+
+var _ Client = &TwilioIPMessagingClient{}
+
+// NewIPMessagingClient creates a new Twilio IP Messaging client.
+func NewIPMessagingClient(accountSid, authToken string) *TwilioIPMessagingClient {
+	rootUrl := IP_MESSAGING_ROOT + "/" + IP_MESSAGING_VERSION
+	return &TwilioIPMessagingClient{TwilioClient{accountSid, authToken, rootUrl}}
+}

--- a/ip_credential.go
+++ b/ip_credential.go
@@ -25,7 +25,7 @@ type IPCredentialList struct {
 
 // NewIPCredential creates a new IP Messaging Credential.
 // Kind must be apns or gcm.
-func NewIPCredential(client Client, friendlyName string, kind string, sandbox bool, apnsCert string, apnsPrivateKey string,
+func NewIPCredential(client *TwilioIPMessagingClient, friendlyName string, kind string, sandbox bool, apnsCert string, apnsPrivateKey string,
 	gcmApiKey string) (*IPCredential, error) {
 	var credential *IPCredential
 
@@ -47,7 +47,7 @@ func NewIPCredential(client Client, friendlyName string, kind string, sandbox bo
 		params.Set("ApiKey", gcmApiKey)
 	}
 
-	res, err := client.postIP(params, "/Credentials.json")
+	res, err := client.post(params, "/Credentials.json")
 
 	if err != nil {
 		return credential, err
@@ -60,10 +60,10 @@ func NewIPCredential(client Client, friendlyName string, kind string, sandbox bo
 }
 
 // GetIPCredential returns information on the specified credential.
-func GetIPCredential(client Client, sid string) (*IPCredential, error) {
+func GetIPCredential(client *TwilioIPMessagingClient, sid string) (*IPCredential, error) {
 	var credential *IPCredential
 
-	res, err := client.getIP(url.Values{}, "/Credentials/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Credentials/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -76,12 +76,12 @@ func GetIPCredential(client Client, sid string) (*IPCredential, error) {
 }
 
 // DeleteIPCredential deletes the given IP Credential.
-func DeleteIPCredential(client Client, sid string) error {
-	return client.deleteIP("/Credentials/" + sid)
+func DeleteIPCredential(client *TwilioIPMessagingClient, sid string) error {
+	return client.delete("/Credentials/" + sid)
 }
 
 // UpdateIPCredential updates an existing IP Messaging Credential.
-func UpdateIPCredential(client Client, sid string, friendlyName string, kind string, sandbox bool) (*IPCredential, error) {
+func UpdateIPCredential(client *TwilioIPMessagingClient, sid string, friendlyName string, kind string, sandbox bool) (*IPCredential, error) {
 	var credential *IPCredential
 
 	params := url.Values{}
@@ -93,7 +93,7 @@ func UpdateIPCredential(client Client, sid string, friendlyName string, kind str
 		params.Set("Sandbox", "false")
 	}
 
-	res, err := client.postIP(params, "/Credentials/"+sid+".json")
+	res, err := client.post(params, "/Credentials/"+sid+".json")
 
 	if err != nil {
 		return credential, err
@@ -106,10 +106,10 @@ func UpdateIPCredential(client Client, sid string, friendlyName string, kind str
 }
 
 // ListIPCredentials returns the first page of credentials.
-func ListIPCredentials(client Client) (*IPCredentialList, error) {
+func ListIPCredentials(client *TwilioIPMessagingClient) (*IPCredentialList, error) {
 	var credentialList *IPCredentialList
 
-	body, err := client.getIP(nil, "/Credentials.json")
+	body, err := client.get(nil, "/Credentials.json")
 
 	if err != nil {
 		return credentialList, err
@@ -186,7 +186,7 @@ func (s *IPCredentialList) getPage(uri string) (*IPCredentialList, error) {
 
 	client := s.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return credentialList, err

--- a/ip_credential.go
+++ b/ip_credential.go
@@ -1,0 +1,200 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPCredential is a IP Messaging Credential resource.
+type IPCredential struct {
+	Sid          string `json:"sid"`
+	AccountSid   string `json:"account_sid"`
+	FriendlyName string `json:"friendly_name"`
+	Type         string `json:"type"` // apns or gcm
+	Sandbox      bool   `json:"sandbox"`
+	URL          string `json:"url"`
+}
+
+// IPCredentialList gives the results for querying the set of credentials. Returns the first page
+// by default.
+type IPCredentialList struct {
+	Client      Client
+	Credentials []IPCredential `json:"credentials"`
+	Meta        Meta           `json:"meta"`
+}
+
+// NewIPCredential creates a new IP Messaging Credential.
+// Kind must be apns or gcm.
+func NewIPCredential(client Client, friendlyName string, kind string, sandbox bool, apnsCert string, apnsPrivateKey string,
+	gcmApiKey string) (*IPCredential, error) {
+	var credential *IPCredential
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("Type", kind)
+	if sandbox {
+		params.Set("Sandbox", "true")
+	} else {
+		params.Set("Sandbox", "false")
+	}
+	if apnsCert != "" {
+		params.Set("Certificate", apnsCert)
+	}
+	if apnsPrivateKey != "" {
+		params.Set("PrivateKey", apnsPrivateKey)
+	}
+	if gcmApiKey != "" {
+		params.Set("ApiKey", gcmApiKey)
+	}
+
+	res, err := client.postIP(params, "/Credentials.json")
+
+	if err != nil {
+		return credential, err
+	}
+
+	credential = new(IPCredential)
+	err = json.Unmarshal(res, credential)
+
+	return credential, err
+}
+
+// GetIPCredential returns information on the specified credential.
+func GetIPCredential(client Client, sid string) (*IPCredential, error) {
+	var credential *IPCredential
+
+	res, err := client.getIP(url.Values{}, "/Credentials/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	credential = new(IPCredential)
+	err = json.Unmarshal(res, credential)
+
+	return credential, err
+}
+
+// DeleteIPCredential deletes the given IP Credential.
+func DeleteIPCredential(client Client, sid string) error {
+	return client.deleteIP("/Credentials/" + sid)
+}
+
+// UpdateIPCredential updates an existing IP Messaging Credential.
+func UpdateIPCredential(client Client, sid string, friendlyName string, kind string, sandbox bool) (*IPCredential, error) {
+	var credential *IPCredential
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("Type", kind)
+	if sandbox {
+		params.Set("Sandbox", "true")
+	} else {
+		params.Set("Sandbox", "false")
+	}
+
+	res, err := client.postIP(params, "/Credentials/"+sid+".json")
+
+	if err != nil {
+		return credential, err
+	}
+
+	credential = new(IPCredential)
+	err = json.Unmarshal(res, credential)
+
+	return credential, err
+}
+
+// ListIPCredentials returns the first page of credentials.
+func ListIPCredentials(client Client) (*IPCredentialList, error) {
+	var credentialList *IPCredentialList
+
+	body, err := client.getIP(nil, "/Credentials.json")
+
+	if err != nil {
+		return credentialList, err
+	}
+
+	credentialList = new(IPCredentialList)
+	credentialList.Client = client
+	err = json.Unmarshal(body, credentialList)
+
+	return credentialList, err
+}
+
+// GetCredentials returns the current page of credentials.
+func (s *IPCredentialList) GetCredentials() []IPCredential {
+	return s.Credentials
+}
+
+// GetAllCredentials returns all of the credentials from all of the pages (from here forward).
+func (s *IPCredentialList) GetAllCredentials() ([]IPCredential, error) {
+	credentials := s.Credentials
+	t := s
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		credentials = append(credentials, t.Credentials...)
+	}
+	return credentials, nil
+}
+
+// HasNextPage returns whether or not there is a next page of credentials.
+func (s *IPCredentialList) HasNextPage() bool {
+	return s.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of credentials.
+func (s *IPCredentialList) NextPage() (*IPCredentialList, error) {
+	if !s.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (s *IPCredentialList) HasPreviousPage() bool {
+	return s.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of credentials.
+func (s *IPCredentialList) PreviousPage() (*IPCredentialList, error) {
+	if !s.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of credentials.
+func (s *IPCredentialList) FirstPage() (*IPCredentialList, error) {
+	return s.getPage(s.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of credentials.
+func (s *IPCredentialList) LastPage() (*IPCredentialList, error) {
+	return s.getPage(s.Meta.LastPageUri)
+}
+
+func (s *IPCredentialList) getPage(uri string) (*IPCredentialList, error) {
+	var credentialList *IPCredentialList
+
+	client := s.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return credentialList, err
+	}
+
+	credentialList = new(IPCredentialList)
+	credentialList.Client = client
+	err = json.Unmarshal(body, credentialList)
+
+	return credentialList, err
+}

--- a/ip_integration_test.go
+++ b/ip_integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestIntegrationIPMessaging(t *testing.T) {
 	CheckTestEnv(t)
 
-	client := NewClient(API_KEY, API_TOKEN)
+	client := NewIPMessagingClient(API_KEY, API_TOKEN)
 
 	service, err := NewIPService(client, "integration_test", "", "", 60*time.Second, nil)
 

--- a/ip_integration_test.go
+++ b/ip_integration_test.go
@@ -1,0 +1,177 @@
+package twiliogo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationIPMessaging(t *testing.T) {
+	CheckTestEnv(t)
+
+	client := NewClient(API_KEY, API_TOKEN)
+
+	service, err := NewIPService(client, "integration_test", "", "", 60*time.Second, nil)
+
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to create service: %v", err)) {
+		return
+	}
+	ssid := service.Sid
+	if !assert.NotEqual(t, "", ssid, "Service SID was empty") {
+		return
+	}
+
+	defer DeleteIPService(client, ssid)
+	serviceList, err := ListIPServices(client)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to retrieve service list: %v", err)) {
+		return
+	}
+	services, err := serviceList.GetAllServices()
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to get all services: %v", err)) {
+		return
+	}
+
+	found := false
+	for _, s := range services {
+		if s.FriendlyName == "integration_test" && s.Sid == ssid {
+			found = true
+			break
+		}
+	}
+	if !assert.True(t, found, "Could not find service") {
+		return
+	}
+
+	channel, err := NewIPChannel(client, ssid, "integration-channel", "", false, "")
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to create channel: %v", err)) {
+		return
+	}
+	csid := channel.Sid
+	if !assert.NotEqual(t, "", csid, "Channel SID was empty") {
+		return
+	}
+
+	channelList, err := ListIPChannels(client, ssid)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to list channels: %v", err)) {
+		return
+	}
+	channels, err := channelList.GetAllChannels()
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to get all channels: %v", err)) {
+		return
+	}
+
+	found = false
+	for _, c := range channels {
+		if c.Sid == csid {
+			found = true
+			break
+		}
+	}
+	if !assert.True(t, found, "Could not find channel") {
+		return
+	}
+
+	// disables for now because I don't have keys to test with
+	/*
+		credential, err := NewIPCredential(client, "integration_cred", "gcm", false, "", "", "")
+		if !assert.Nil(t, err, fmt.Sprintf("Failed to create credential: %v", err)) {
+			return
+		}
+		credSid := credential.Sid
+		if !assert.NotEqual(t, "", credSid, "Credential SID was empty") {
+			return
+		}
+	*/
+
+	role, err := NewIPRole(client, ssid, "integration_role", "channel",
+		[]string{PermissionSendMessage, PermissionEditOwnMessage})
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to create role: %v", err)) {
+		return
+	}
+
+	roleSid := role.Sid
+	if !assert.NotEqual(t, "", roleSid, "Role SID was empty") {
+		return
+	}
+
+	user, err := NewIPUser(client, ssid, "integration_user", "")
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to create user: %v", err)) {
+		return
+	}
+
+	userSid := user.Sid
+	if !assert.NotEqual(t, "", userSid, "User SID was empty") {
+		return
+	}
+
+	member, err := AddIPMemberToChannel(client, ssid, csid, "integration_user", roleSid)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to add member: %v", err)) {
+		return
+	}
+
+	memberSid := member.Sid
+	if !assert.NotEqual(t, "", memberSid, "Member SID was empty") {
+		return
+	}
+
+	_, err = NewIPUser(client, ssid, "integration_user2", "")
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to create user: %v", err)) {
+		return
+	}
+	_, err = AddIPMemberToChannel(client, ssid, csid, "integration_user2", roleSid)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to add member: %v", err)) {
+		return
+	}
+
+	memberList, err := ListIPMembers(client, ssid, csid)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to add member: %v", err)) {
+		return
+	}
+
+	members, err := memberList.GetAllMembers()
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to list members: %v", err)) {
+		return
+	}
+
+	found = false
+	for _, m := range members {
+		if m.Sid == memberSid && m.Identity == member.Identity {
+			found = true
+			break
+		}
+	}
+
+	if !assert.True(t, found, "Could not find member") {
+		return
+	}
+
+	message, err := SendIPMessageToChannel(client, ssid, csid, "integration_user2", "testing integration")
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to send message: %v", err)) {
+		return
+	}
+	if !assert.NotEqual(t, "", message.Sid, "Message SID was empty") {
+		return
+	}
+
+	found = false
+	messageList, err := ListIPMessages(client, ssid, csid)
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to list messages: %v", err)) {
+		return
+	}
+	messages, err := messageList.GetAllMessages()
+	if !assert.Nil(t, err, fmt.Sprintf("Failed to get all messages: %v", err)) {
+		return
+	}
+	found = false
+	for _, m := range messages {
+		if m.Sid == message.Sid && m.Body == "testing integration" {
+			found = true
+			break
+		}
+	}
+	if !assert.True(t, found, "Could not find message") {
+		return
+	}
+}

--- a/ip_member.go
+++ b/ip_member.go
@@ -1,0 +1,164 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPMember is a IP Messaging Member resource.
+type IPMember struct {
+	Sid         string  `json:"sid"`
+	AccountSid  string  `json:"account_sid"`
+	ChannelSid  string  `json:"channel_sid"`
+	ServiceSid  string  `json:"service_sid"`
+	Identity    string  `json:"identity"`
+	RoleSid     *string `json:"role_sid"`
+	DateCreated string  `json:"date_created"`
+	DateUpdated string  `json:"date_updated"`
+	URL         string  `json:"url"`
+}
+
+// IPMemberList gives the results for querying the set of members. Returns the first page
+// by default.
+type IPMemberList struct {
+	Client  Client
+	Members []IPMember `json:"members"`
+	Meta    Meta       `json:"meta"`
+}
+
+// AddIPMemberToChannel adds a member to a channel.
+func AddIPMemberToChannel(client Client, serviceSid string, channelSid string, identity string, roleSid string) (*IPMember, error) {
+	var member *IPMember
+
+	params := url.Values{}
+	params.Set("Identity", identity)
+	if roleSid != "" {
+		params.Set("RoleSid", roleSid)
+	}
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
+
+	if err != nil {
+		return member, err
+	}
+
+	member = new(IPMember)
+	err = json.Unmarshal(res, member)
+
+	return member, err
+}
+
+// GetIPChannelMember returns the specified IP Member in the channel.
+func GetIPChannelMember(client Client, serviceSid, channelSid, sid string) (*IPMember, error) {
+	var member *IPMember
+
+	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	member = new(IPMember)
+	err = json.Unmarshal(res, member)
+
+	return member, err
+}
+
+// RemoveIPMemberFromChannel removes the given member from the channel.
+func RemoveIPMemberFromChannel(client Client, serviceSid, channelSid, sid string) error {
+	return client.deleteIP("/Services/" + serviceSid + "/Channels/" + channelSid + "/Members/" + sid)
+}
+
+// ListIPMembers returns the first page of members.
+func ListIPMembers(client Client, serviceSid, channelSid string) (*IPMemberList, error) {
+	var memberList *IPMemberList
+
+	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
+
+	if err != nil {
+		return memberList, err
+	}
+
+	memberList = new(IPMemberList)
+	memberList.Client = client
+	err = json.Unmarshal(body, memberList)
+
+	return memberList, err
+}
+
+// GetMembers recturns the current page of members.
+func (c *IPMemberList) GetMembers() []IPMember {
+	return c.Members
+}
+
+// GetAllMembers returns all of the members from all of the pages (from here forward).
+func (c *IPMemberList) GetAllMembers() ([]IPMember, error) {
+	members := c.Members
+	t := c
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, t.Members...)
+	}
+	return members, nil
+}
+
+// HasNextPage returns whether or not there is a next page of members.
+func (c *IPMemberList) HasNextPage() bool {
+	return c.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of members.
+func (c *IPMemberList) NextPage() (*IPMemberList, error) {
+	if !c.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (c *IPMemberList) HasPreviousPage() bool {
+	return c.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of members.
+func (c *IPMemberList) PreviousPage() (*IPMemberList, error) {
+	if !c.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of members.
+func (c *IPMemberList) FirstPage() (*IPMemberList, error) {
+	return c.getPage(c.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of members.
+func (c *IPMemberList) LastPage() (*IPMemberList, error) {
+	return c.getPage(c.Meta.LastPageUri)
+}
+
+func (c *IPMemberList) getPage(uri string) (*IPMemberList, error) {
+	var memberList *IPMemberList
+
+	client := c.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return memberList, err
+	}
+
+	memberList = new(IPMemberList)
+	memberList.Client = client
+	err = json.Unmarshal(body, memberList)
+
+	return memberList, err
+}

--- a/ip_member.go
+++ b/ip_member.go
@@ -27,7 +27,7 @@ type IPMemberList struct {
 }
 
 // AddIPMemberToChannel adds a member to a channel.
-func AddIPMemberToChannel(client Client, serviceSid string, channelSid string, identity string, roleSid string) (*IPMember, error) {
+func AddIPMemberToChannel(client *TwilioIPMessagingClient, serviceSid string, channelSid string, identity string, roleSid string) (*IPMember, error) {
 	var member *IPMember
 
 	params := url.Values{}
@@ -36,7 +36,7 @@ func AddIPMemberToChannel(client Client, serviceSid string, channelSid string, i
 		params.Set("RoleSid", roleSid)
 	}
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
 
 	if err != nil {
 		return member, err
@@ -49,10 +49,10 @@ func AddIPMemberToChannel(client Client, serviceSid string, channelSid string, i
 }
 
 // GetIPChannelMember returns the specified IP Member in the channel.
-func GetIPChannelMember(client Client, serviceSid, channelSid, sid string) (*IPMember, error) {
+func GetIPChannelMember(client *TwilioIPMessagingClient, serviceSid, channelSid, sid string) (*IPMember, error) {
 	var member *IPMember
 
-	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -65,15 +65,15 @@ func GetIPChannelMember(client Client, serviceSid, channelSid, sid string) (*IPM
 }
 
 // RemoveIPMemberFromChannel removes the given member from the channel.
-func RemoveIPMemberFromChannel(client Client, serviceSid, channelSid, sid string) error {
-	return client.deleteIP("/Services/" + serviceSid + "/Channels/" + channelSid + "/Members/" + sid)
+func RemoveIPMemberFromChannel(client *TwilioIPMessagingClient, serviceSid, channelSid, sid string) error {
+	return client.delete("/Services/" + serviceSid + "/Channels/" + channelSid + "/Members/" + sid)
 }
 
 // ListIPMembers returns the first page of members.
-func ListIPMembers(client Client, serviceSid, channelSid string) (*IPMemberList, error) {
+func ListIPMembers(client *TwilioIPMessagingClient, serviceSid, channelSid string) (*IPMemberList, error) {
 	var memberList *IPMemberList
 
-	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
+	body, err := client.get(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Members.json")
 
 	if err != nil {
 		return memberList, err
@@ -150,7 +150,7 @@ func (c *IPMemberList) getPage(uri string) (*IPMemberList, error) {
 
 	client := c.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return memberList, err

--- a/ip_message.go
+++ b/ip_message.go
@@ -1,0 +1,160 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPMessage is a IP Messaging Message resource.
+type IPMessage struct {
+	Sid         string `json:"sid"`
+	AccountSid  string `json:"account_sid"`
+	ServiceSid  string `json:"service_sid"`
+	To          string `json:"to"` // channel sid
+	DateCreated string `json:"date_created"`
+	DateUpdated string `json:"date_updated"`
+	WasEdited   bool   `json:"was_edited"`
+	From        string `json:"from"` // identity
+	Body        string `json:"body"`
+	URL         string `json:"url"`
+}
+
+// IPMessageList gives the results for querying the set of messages. Returns the first page
+// by default.
+type IPMessageList struct {
+	Client   Client
+	Messages []IPMessage `json:"messages"`
+	Meta     Meta        `json:"meta"`
+}
+
+// SendIPMessageToChannel sends a message to a channel.
+func SendIPMessageToChannel(client Client, serviceSid string, channelSid string, from string, body string) (*IPMessage, error) {
+	var message *IPMessage
+
+	params := url.Values{}
+	params.Set("Body", body)
+	if from != "" {
+		params.Set("From", from)
+	}
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
+
+	if err != nil {
+		return message, err
+	}
+
+	message = new(IPMessage)
+	err = json.Unmarshal(res, message)
+
+	return message, err
+}
+
+// GetIPChannelMessage returns the specified IP Message in the channel.
+func GetIPChannelMessage(client Client, serviceSid, channelSid, sid string) (*IPMessage, error) {
+	var message *IPMessage
+
+	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	message = new(IPMessage)
+	err = json.Unmarshal(res, message)
+
+	return message, err
+}
+
+// ListIPMessages returns the first page of messages for a channel.
+func ListIPMessages(client Client, serviceSid, channelSid string) (*IPMessageList, error) {
+	var messageList *IPMessageList
+
+	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
+
+	if err != nil {
+		return messageList, err
+	}
+
+	messageList = new(IPMessageList)
+	messageList.Client = client
+	err = json.Unmarshal(body, messageList)
+
+	return messageList, err
+}
+
+// GetMessages recturns the current page of messages.
+func (c *IPMessageList) GetMessages() []IPMessage {
+	return c.Messages
+}
+
+// GetAllMessages returns all of the messages from all of the pages (from here forward).
+func (c *IPMessageList) GetAllMessages() ([]IPMessage, error) {
+	messages := c.Messages
+	t := c
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, t.Messages...)
+	}
+	return messages, nil
+}
+
+// HasNextPage returns whether or not there is a next page of messages.
+func (c *IPMessageList) HasNextPage() bool {
+	return c.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of messages.
+func (c *IPMessageList) NextPage() (*IPMessageList, error) {
+	if !c.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (c *IPMessageList) HasPreviousPage() bool {
+	return c.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of messages.
+func (c *IPMessageList) PreviousPage() (*IPMessageList, error) {
+	if !c.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return c.getPage(c.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of messages.
+func (c *IPMessageList) FirstPage() (*IPMessageList, error) {
+	return c.getPage(c.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of messages.
+func (c *IPMessageList) LastPage() (*IPMessageList, error) {
+	return c.getPage(c.Meta.LastPageUri)
+}
+
+func (c *IPMessageList) getPage(uri string) (*IPMessageList, error) {
+	var messageList *IPMessageList
+
+	client := c.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return messageList, err
+	}
+
+	messageList = new(IPMessageList)
+	messageList.Client = client
+	err = json.Unmarshal(body, messageList)
+
+	return messageList, err
+}

--- a/ip_message.go
+++ b/ip_message.go
@@ -28,7 +28,7 @@ type IPMessageList struct {
 }
 
 // SendIPMessageToChannel sends a message to a channel.
-func SendIPMessageToChannel(client Client, serviceSid string, channelSid string, from string, body string) (*IPMessage, error) {
+func SendIPMessageToChannel(client *TwilioIPMessagingClient, serviceSid string, channelSid string, from string, body string) (*IPMessage, error) {
 	var message *IPMessage
 
 	params := url.Values{}
@@ -37,7 +37,7 @@ func SendIPMessageToChannel(client Client, serviceSid string, channelSid string,
 		params.Set("From", from)
 	}
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
 
 	if err != nil {
 		return message, err
@@ -50,10 +50,10 @@ func SendIPMessageToChannel(client Client, serviceSid string, channelSid string,
 }
 
 // GetIPChannelMessage returns the specified IP Message in the channel.
-func GetIPChannelMessage(client Client, serviceSid, channelSid, sid string) (*IPMessage, error) {
+func GetIPChannelMessage(client *TwilioIPMessagingClient, serviceSid, channelSid, sid string) (*IPMessage, error) {
 	var message *IPMessage
 
-	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -66,10 +66,10 @@ func GetIPChannelMessage(client Client, serviceSid, channelSid, sid string) (*IP
 }
 
 // ListIPMessages returns the first page of messages for a channel.
-func ListIPMessages(client Client, serviceSid, channelSid string) (*IPMessageList, error) {
+func ListIPMessages(client *TwilioIPMessagingClient, serviceSid, channelSid string) (*IPMessageList, error) {
 	var messageList *IPMessageList
 
-	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
+	body, err := client.get(nil, "/Services/"+serviceSid+"/Channels/"+channelSid+"/Messages.json")
 
 	if err != nil {
 		return messageList, err
@@ -146,7 +146,7 @@ func (c *IPMessageList) getPage(uri string) (*IPMessageList, error) {
 
 	client := c.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return messageList, err

--- a/ip_role.go
+++ b/ip_role.go
@@ -21,7 +21,7 @@ type IPRole struct {
 // IPRoleList gives the results for querying the set of roles. Returns the first page
 // by default.
 type IPRoleList struct {
-	Client Client
+	Client *TwilioIPMessagingClient
 	Roles  []IPRole `json:"roles"`
 	Meta   Meta     `json:"meta"`
 }
@@ -47,7 +47,7 @@ const (
 // NewIPRole creates a new IP Messaging Role.
 // kind should be "channel" or "service".
 // permissions should be a subset of the permissions consts above.
-func NewIPRole(client Client, serviceSid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
+func NewIPRole(client *TwilioIPMessagingClient, serviceSid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
 	var role *IPRole
 
 	params := url.Values{}
@@ -59,7 +59,7 @@ func NewIPRole(client Client, serviceSid string, friendlyName string, kind strin
 		}
 	}
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Roles.json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Roles.json")
 
 	if err != nil {
 		return role, err
@@ -72,10 +72,10 @@ func NewIPRole(client Client, serviceSid string, friendlyName string, kind strin
 }
 
 // GetIPRole returns information on the specified role.
-func GetIPRole(client Client, serviceSid, sid string) (*IPRole, error) {
+func GetIPRole(client *TwilioIPMessagingClient, serviceSid, sid string) (*IPRole, error) {
 	var role *IPRole
 
-	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Roles/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+serviceSid+"/Roles/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -88,12 +88,12 @@ func GetIPRole(client Client, serviceSid, sid string) (*IPRole, error) {
 }
 
 // DeleteIPRole deletes the given IP Role.
-func DeleteIPRole(client Client, serviceSid, sid string) error {
-	return client.deleteIP("/Services/" + serviceSid + "/Roles/" + sid)
+func DeleteIPRole(client *TwilioIPMessagingClient, serviceSid, sid string) error {
+	return client.delete("/Services/" + serviceSid + "/Roles/" + sid)
 }
 
 // UpdateIPRole updates an existing IP Messaging Role.
-func UpdateIPRole(client Client, serviceSid string, sid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
+func UpdateIPRole(client *TwilioIPMessagingClient, serviceSid string, sid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
 	var role *IPRole
 
 	params := url.Values{}
@@ -105,7 +105,7 @@ func UpdateIPRole(client Client, serviceSid string, sid string, friendlyName str
 		}
 	}
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Roles/"+sid+".json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Roles/"+sid+".json")
 
 	if err != nil {
 		return role, err
@@ -118,10 +118,10 @@ func UpdateIPRole(client Client, serviceSid string, sid string, friendlyName str
 }
 
 // ListIPRoles returns the first page of roles.
-func ListIPRoles(client Client, serviceSid string) (*IPRoleList, error) {
+func ListIPRoles(client *TwilioIPMessagingClient, serviceSid string) (*IPRoleList, error) {
 	var roleList *IPRoleList
 
-	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Roles.json")
+	body, err := client.get(nil, "/Services/"+serviceSid+"/Roles.json")
 
 	if err != nil {
 		return roleList, err
@@ -198,7 +198,7 @@ func (s *IPRoleList) getPage(uri string) (*IPRoleList, error) {
 
 	client := s.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return roleList, err

--- a/ip_role.go
+++ b/ip_role.go
@@ -1,0 +1,212 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPRole is a IP Messaging Role resource.
+type IPRole struct {
+	Sid          string   `json:"sid"`
+	AccountSid   string   `json:"account_sid"`
+	ServiceSid   string   `json:"service_sid"`
+	FriendlyName string   `json:"friendly_name"`
+	Type         string   `json:"type"`
+	Permissions  []string `json:"permissions"`
+	DateCreated  string   `json:"date_created"`
+	DateUpdated  string   `json:"date_updated"`
+	URL          string   `json:"url"`
+}
+
+// IPRoleList gives the results for querying the set of roles. Returns the first page
+// by default.
+type IPRoleList struct {
+	Client Client
+	Roles  []IPRole `json:"roles"`
+	Meta   Meta     `json:"meta"`
+}
+
+// Permissions allowed for IP Roles.
+const (
+	PermissionCreateChannel         = "createChannel"
+	PermissionJoinChannel           = "joinChannel"
+	PermissionDestroyChannel        = "destroyChannel"
+	PermissionInviteMember          = "inviteMember"
+	PermissionRemoveMember          = "removeMember"
+	PermissionEditChannelName       = "editChannelName"
+	PermissionEditChannelAttributes = "editChannelAttributes"
+	PermissionAddMember             = "addMember"
+	PermissionEditAnyMessage        = "editAnyMessage"
+	PermissionDeleteAnyMessage      = "deleteAnyMessage"
+	PermissionSendMessage           = "sendMessage"
+	PermissionLeaveChannel          = "leaveChannel"
+	PermissionEditOwnMessage        = "editOwnMessage"
+	PermissionDeleteOwnMessage      = "deleteOwnMessage"
+)
+
+// NewIPRole creates a new IP Messaging Role.
+// kind should be "channel" or "service".
+// permissions should be a subset of the permissions consts above.
+func NewIPRole(client Client, serviceSid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
+	var role *IPRole
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("Type", kind)
+	if permissions != nil {
+		for _, p := range permissions {
+			params.Add("Permission", p)
+		}
+	}
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Roles.json")
+
+	if err != nil {
+		return role, err
+	}
+
+	role = new(IPRole)
+	err = json.Unmarshal(res, role)
+
+	return role, err
+}
+
+// GetIPRole returns information on the specified role.
+func GetIPRole(client Client, serviceSid, sid string) (*IPRole, error) {
+	var role *IPRole
+
+	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Roles/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	role = new(IPRole)
+	err = json.Unmarshal(res, role)
+
+	return role, err
+}
+
+// DeleteIPRole deletes the given IP Role.
+func DeleteIPRole(client Client, serviceSid, sid string) error {
+	return client.deleteIP("/Services/" + serviceSid + "/Roles/" + sid)
+}
+
+// UpdateIPRole updates an existing IP Messaging Role.
+func UpdateIPRole(client Client, serviceSid string, sid string, friendlyName string, kind string, permissions []string) (*IPRole, error) {
+	var role *IPRole
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("Type", kind)
+	if permissions != nil {
+		for _, p := range permissions {
+			params.Add("Permission", p)
+		}
+	}
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Roles/"+sid+".json")
+
+	if err != nil {
+		return role, err
+	}
+
+	role = new(IPRole)
+	err = json.Unmarshal(res, role)
+
+	return role, err
+}
+
+// ListIPRoles returns the first page of roles.
+func ListIPRoles(client Client, serviceSid string) (*IPRoleList, error) {
+	var roleList *IPRoleList
+
+	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Roles.json")
+
+	if err != nil {
+		return roleList, err
+	}
+
+	roleList = new(IPRoleList)
+	roleList.Client = client
+	err = json.Unmarshal(body, roleList)
+
+	return roleList, err
+}
+
+// GetRoles returns the current page of roles.
+func (s *IPRoleList) GetRoles() []IPRole {
+	return s.Roles
+}
+
+// GetAllRoles returns all of the roles from all of the pages (from here forward).
+func (s *IPRoleList) GetAllRoles() ([]IPRole, error) {
+	roles := s.Roles
+	t := s
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, t.Roles...)
+	}
+	return roles, nil
+}
+
+// HasNextPage returns whether or not there is a next page of roles.
+func (s *IPRoleList) HasNextPage() bool {
+	return s.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of roles.
+func (s *IPRoleList) NextPage() (*IPRoleList, error) {
+	if !s.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (s *IPRoleList) HasPreviousPage() bool {
+	return s.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of roles.
+func (s *IPRoleList) PreviousPage() (*IPRoleList, error) {
+	if !s.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of roles.
+func (s *IPRoleList) FirstPage() (*IPRoleList, error) {
+	return s.getPage(s.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of roles.
+func (s *IPRoleList) LastPage() (*IPRoleList, error) {
+	return s.getPage(s.Meta.LastPageUri)
+}
+
+func (s *IPRoleList) getPage(uri string) (*IPRoleList, error) {
+	var roleList *IPRoleList
+
+	client := s.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return roleList, err
+	}
+
+	roleList = new(IPRoleList)
+	roleList.Client = client
+	err = json.Unmarshal(body, roleList)
+
+	return roleList, err
+}

--- a/ip_service.go
+++ b/ip_service.go
@@ -85,7 +85,7 @@ func durationToISO8601(d time.Duration) (string, error) {
 }
 
 // NewIPService creates a new IP Messaging Service.
-func NewIPService(client Client, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
+func NewIPService(client *TwilioIPMessagingClient, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
 	typingIndicatorTimeout time.Duration, webhooks Webhooks) (*IPService, error) {
 
 	timeout, err := durationToISO8601(typingIndicatorTimeout)
@@ -106,7 +106,7 @@ func NewIPService(client Client, friendlyName string, defaultServiceRoleSid stri
 		}
 	}
 
-	res, err := client.postIP(params, "/Services.json")
+	res, err := client.post(params, "/Services.json")
 
 	if err != nil {
 		return service, err
@@ -119,10 +119,10 @@ func NewIPService(client Client, friendlyName string, defaultServiceRoleSid stri
 }
 
 // GetIPService returns information on the specified service.
-func GetIPService(client Client, sid string) (*IPService, error) {
+func GetIPService(client *TwilioIPMessagingClient, sid string) (*IPService, error) {
 	var service *IPService
 
-	res, err := client.getIP(url.Values{}, "/Services/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -135,12 +135,12 @@ func GetIPService(client Client, sid string) (*IPService, error) {
 }
 
 // DeleteIPService deletes the given IP Service.
-func DeleteIPService(client Client, sid string) error {
-	return client.deleteIP("/Services/" + sid)
+func DeleteIPService(client *TwilioIPMessagingClient, sid string) error {
+	return client.delete("/Services/" + sid)
 }
 
 // UpdateIPService updates an existing IP Messaging Service.
-func UpdateIPService(client Client, sid string, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
+func UpdateIPService(client *TwilioIPMessagingClient, sid string, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
 	typingIndicatorTimeout time.Duration, webhooks Webhooks) (*IPService, error) {
 
 	timeout, err := durationToISO8601(typingIndicatorTimeout)
@@ -159,7 +159,7 @@ func UpdateIPService(client Client, sid string, friendlyName string, defaultServ
 		params.Set(k, v)
 	}
 
-	res, err := client.postIP(params, "/Services/"+sid+".json")
+	res, err := client.post(params, "/Services/"+sid+".json")
 
 	if err != nil {
 		return service, err
@@ -172,10 +172,10 @@ func UpdateIPService(client Client, sid string, friendlyName string, defaultServ
 }
 
 // ListIPServices returns the first page of services.
-func ListIPServices(client Client) (*IPServiceList, error) {
+func ListIPServices(client *TwilioIPMessagingClient) (*IPServiceList, error) {
 	var serviceList *IPServiceList
 
-	body, err := client.getIP(nil, "/Services.json")
+	body, err := client.get(nil, "/Services.json")
 
 	if err != nil {
 		return serviceList, err
@@ -252,7 +252,7 @@ func (s *IPServiceList) getPage(uri string) (*IPServiceList, error) {
 
 	client := s.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return serviceList, err

--- a/ip_service.go
+++ b/ip_service.go
@@ -1,0 +1,266 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"time"
+)
+
+// IPService is a IP Messaging Service resource.
+type IPService struct {
+	Sid                    string            `json:"sid"`
+	AccountSid             string            `json:"account_sid"`
+	FriendlyName           string            `json:"friendly_name"`
+	DateCreated            string            `json:"date_created"`
+	DateUpdated            string            `json:"date_updated"`
+	DefaultServiceRoleSid  string            `json:"default_service_role_sid"`
+	DefaultChannelRoleSid  string            `json:"default_channel_role_sid"`
+	TypingIndicatorTimeout uint              `json:"typing_indicator_timeout"`
+	Webhooks               map[string]string `json:"webhooks"`
+	URL                    string            `json:"url"`
+	Links                  map[string]string `json:"links"`
+}
+
+// Meta is a metadata type for the IP messaging services.
+type Meta struct {
+	Start           int    `json:"start"`
+	Total           int    `json:"total"`
+	NumPages        int    `json:"num_pages"`
+	Page            int    `json:"page"`
+	PageSize        int    `json:"page_size"`
+	End             int    `json:"end"`
+	Uri             string `json:"uri"`
+	FirstPageUri    string `json:"first_page_uri"`
+	LastPageUri     string `json:"last_page_uri"`
+	NextPageUri     string `json:"next_page_uri"`
+	PreviousPageUri string `json:"previous_page_uri"`
+	Key             string `json:"key"`
+}
+
+// IPServiceList gives the results for querying the set of services. Returns the first page
+// by default.
+type IPServiceList struct {
+	Client   Client
+	Services []IPService `json:"services"`
+	Meta     Meta        `json:"meta"`
+}
+
+// Webhooks available for services to specify
+const (
+	WebhookOnMessageSend    = "Webhooks.OnMessageSend"
+	WebhookOnMessageRemove  = "Webhooks.OnMessageRemove"
+	WebhookOnMessageUpdate  = "Webhooks.OnMessageUpdate"
+	WebhookOnChannelAdd     = "Webhooks.OnChannelAdd"
+	WebhookOnChannelUpdate  = "Webhooks.OnChannelUpdate"
+	WebhookOnChannelDestroy = "Webhooks.OnChannelDestroy"
+	WebhookOnMemberAdd      = "Webhooks.OnMemberAdd"
+	WebhookOnMemberRemove   = "Webhooks.OnMemberRemove"
+)
+
+// Webhooks are used to define push webhooks for an IP service.
+type Webhooks map[string]string
+
+// NewWebhooks creates a new, empty set of web hooks.
+func NewWebhooks() Webhooks {
+	return Webhooks(make(map[string]string))
+}
+
+// Add adds a new webhook. The name should be one of the Webhook* exported values.
+// Method is the HTTP method (e.g., "POST"). Format should be "xml" or "json".
+func (w Webhooks) Add(name, method, format, url string) {
+	w[name+".Method"] = method
+	w[name+".Format"] = format
+	w[name+".Url"] = url
+}
+
+func durationToISO8601(d time.Duration) (string, error) {
+	if d > time.Hour {
+		return "", fmt.Errorf("Duration is too long: %v", d)
+	}
+	minutes := int(math.Floor(d.Minutes()))
+	seconds := int(math.Floor(d.Minutes()-float64(minutes)) * 60.0)
+	return fmt.Sprintf("PT%dM%dS", minutes, seconds), nil
+}
+
+// NewIPService creates a new IP Messaging Service.
+func NewIPService(client Client, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
+	typingIndicatorTimeout time.Duration, webhooks Webhooks) (*IPService, error) {
+
+	timeout, err := durationToISO8601(typingIndicatorTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var service *IPService
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("DefaultServiceRoleSid", defaultServiceRoleSid)
+	params.Set("DefaultChannelRoleSid", defaultChannelRoleSid)
+	params.Set("TypingIndicatonTimeout", timeout)
+	if webhooks != nil {
+		for k, v := range webhooks {
+			params.Set(k, v)
+		}
+	}
+
+	res, err := client.postIP(params, "/Services.json")
+
+	if err != nil {
+		return service, err
+	}
+
+	service = new(IPService)
+	err = json.Unmarshal(res, service)
+
+	return service, err
+}
+
+// GetIPService returns information on the specified service.
+func GetIPService(client Client, sid string) (*IPService, error) {
+	var service *IPService
+
+	res, err := client.getIP(url.Values{}, "/Services/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	service = new(IPService)
+	err = json.Unmarshal(res, service)
+
+	return service, err
+}
+
+// DeleteIPService deletes the given IP Service.
+func DeleteIPService(client Client, sid string) error {
+	return client.deleteIP("/Services/" + sid)
+}
+
+// UpdateIPService updates an existing IP Messaging Service.
+func UpdateIPService(client Client, sid string, friendlyName string, defaultServiceRoleSid string, defaultChannelRoleSid string,
+	typingIndicatorTimeout time.Duration, webhooks Webhooks) (*IPService, error) {
+
+	timeout, err := durationToISO8601(typingIndicatorTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var service *IPService
+
+	params := url.Values{}
+	params.Set("FriendlyName", friendlyName)
+	params.Set("DefaultServiceRoleSid", defaultServiceRoleSid)
+	params.Set("DefaultChannelRoleSid", defaultChannelRoleSid)
+	params.Set("TypingIndicatonTimeout", timeout)
+	for k, v := range webhooks {
+		params.Set(k, v)
+	}
+
+	res, err := client.postIP(params, "/Services/"+sid+".json")
+
+	if err != nil {
+		return service, err
+	}
+
+	service = new(IPService)
+	err = json.Unmarshal(res, service)
+
+	return service, err
+}
+
+// ListIPServices returns the first page of services.
+func ListIPServices(client Client) (*IPServiceList, error) {
+	var serviceList *IPServiceList
+
+	body, err := client.getIP(nil, "/Services.json")
+
+	if err != nil {
+		return serviceList, err
+	}
+
+	serviceList = new(IPServiceList)
+	serviceList.Client = client
+	err = json.Unmarshal(body, serviceList)
+
+	return serviceList, err
+}
+
+// GetServices returns the current page of services.
+func (s *IPServiceList) GetServices() []IPService {
+	return s.Services
+}
+
+// GetAllServices returns all of the services from all of the pages (from here forward).
+func (s *IPServiceList) GetAllServices() ([]IPService, error) {
+	services := s.Services
+	t := s
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, t.Services...)
+	}
+	return services, nil
+}
+
+// HasNextPage returns whether or not there is a next page of services.
+func (s *IPServiceList) HasNextPage() bool {
+	return s.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of services.
+func (s *IPServiceList) NextPage() (*IPServiceList, error) {
+	if !s.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (s *IPServiceList) HasPreviousPage() bool {
+	return s.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of services.
+func (s *IPServiceList) PreviousPage() (*IPServiceList, error) {
+	if !s.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of services.
+func (s *IPServiceList) FirstPage() (*IPServiceList, error) {
+	return s.getPage(s.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of services.
+func (s *IPServiceList) LastPage() (*IPServiceList, error) {
+	return s.getPage(s.Meta.LastPageUri)
+}
+
+func (s *IPServiceList) getPage(uri string) (*IPServiceList, error) {
+	var serviceList *IPServiceList
+
+	client := s.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return serviceList, err
+	}
+
+	serviceList = new(IPServiceList)
+	serviceList.Client = client
+	err = json.Unmarshal(body, serviceList)
+
+	return serviceList, err
+}

--- a/ip_user.go
+++ b/ip_user.go
@@ -1,0 +1,181 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// IPUser is a IP Messaging User resource.
+type IPUser struct {
+	Sid         string `json:"sid"`
+	AccountSid  string `json:"account_sid"`
+	ServiceSid  string `json:"service_sid"`
+	RoleSid     string `json:"role_sid"`
+	Identity    string `json:"identity"`
+	DateCreated string `json:"date_created"`
+	DateUpdated string `json:"date_updated"`
+	URL         string `json:"url"`
+}
+
+// IPUserList gives the results for querying the set of users. Returns the first page
+// by default.
+type IPUserList struct {
+	Client Client
+	Users  []IPUser `json:"users"`
+	Meta   Meta     `json:"meta"`
+}
+
+// NewIPUser creates a new IP Messaging User.
+func NewIPUser(client Client, serviceSid string, identity string, roleSid string) (*IPUser, error) {
+	var user *IPUser
+
+	params := url.Values{}
+	params.Set("Identity", identity)
+	params.Set("RoleSid", roleSid)
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Users.json")
+
+	if err != nil {
+		return user, err
+	}
+
+	user = new(IPUser)
+	err = json.Unmarshal(res, user)
+
+	return user, err
+}
+
+// GetIPUser returns information on the specified user.
+func GetIPUser(client Client, serviceSid, sid string) (*IPUser, error) {
+	var user *IPUser
+
+	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Users/"+sid+".json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	user = new(IPUser)
+	err = json.Unmarshal(res, user)
+
+	return user, err
+}
+
+// DeleteIPUser deletes the given IP user.
+func DeleteIPUser(client Client, serviceSid, sid string) error {
+	return client.deleteIP("/Services/" + serviceSid + "/Users/" + sid)
+}
+
+// UpdateIPUser updates an existing IP Messaging user.
+func UpdateIPUser(client Client, serviceSid string, sid string, identity string, roleSid string) (*IPUser, error) {
+	var user *IPUser
+
+	params := url.Values{}
+	params.Set("Identity", identity)
+	params.Set("RoleSid", roleSid)
+
+	res, err := client.postIP(params, "/Services/"+serviceSid+"/Users/"+sid+".json")
+
+	if err != nil {
+		return user, err
+	}
+
+	user = new(IPUser)
+	err = json.Unmarshal(res, user)
+
+	return user, err
+}
+
+// ListIPUsers returns the first page of users.
+func ListIPUsers(client Client, serviceSid string) (*IPUserList, error) {
+	var userList *IPUserList
+
+	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Users.json")
+
+	if err != nil {
+		return userList, err
+	}
+
+	userList = new(IPUserList)
+	userList.Client = client
+	err = json.Unmarshal(body, userList)
+
+	return userList, err
+}
+
+// GetUsers returns the current page of users.
+func (s *IPUserList) GetUsers() []IPUser {
+	return s.Users
+}
+
+// GetAllUsers returns all of the users from all of the pages (from here forward).
+func (s *IPUserList) GetAllUsers() ([]IPUser, error) {
+	users := s.Users
+	t := s
+
+	for t.HasNextPage() {
+		var err error
+		t, err = t.NextPage()
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, t.Users...)
+	}
+	return users, nil
+}
+
+// HasNextPage returns whether or not there is a next page of users.
+func (s *IPUserList) HasNextPage() bool {
+	return s.Meta.NextPageUri != ""
+}
+
+// NextPage returns the next page of users.
+func (s *IPUserList) NextPage() (*IPUserList, error) {
+	if !s.HasNextPage() {
+		return nil, Error{"No next page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// HasPreviousPage indicates whether or not there is a previous page of results.
+func (s *IPUserList) HasPreviousPage() bool {
+	return s.Meta.PreviousPageUri != ""
+}
+
+// PreviousPage returns the previous page of users.
+func (s *IPUserList) PreviousPage() (*IPUserList, error) {
+	if !s.HasPreviousPage() {
+		return nil, Error{"No previous page"}
+	}
+
+	return s.getPage(s.Meta.NextPageUri)
+}
+
+// FirstPage returns the first page of users.
+func (s *IPUserList) FirstPage() (*IPUserList, error) {
+	return s.getPage(s.Meta.FirstPageUri)
+}
+
+// LastPage returns the last page of users.
+func (s *IPUserList) LastPage() (*IPUserList, error) {
+	return s.getPage(s.Meta.LastPageUri)
+}
+
+func (s *IPUserList) getPage(uri string) (*IPUserList, error) {
+	var userList *IPUserList
+
+	client := s.Client
+
+	body, err := client.getIP(nil, uri)
+
+	if err != nil {
+		return userList, err
+	}
+
+	userList = new(IPUserList)
+	userList.Client = client
+	err = json.Unmarshal(body, userList)
+
+	return userList, err
+}

--- a/ip_user.go
+++ b/ip_user.go
@@ -20,20 +20,20 @@ type IPUser struct {
 // IPUserList gives the results for querying the set of users. Returns the first page
 // by default.
 type IPUserList struct {
-	Client Client
+	Client *TwilioIPMessagingClient
 	Users  []IPUser `json:"users"`
 	Meta   Meta     `json:"meta"`
 }
 
 // NewIPUser creates a new IP Messaging User.
-func NewIPUser(client Client, serviceSid string, identity string, roleSid string) (*IPUser, error) {
+func NewIPUser(client *TwilioIPMessagingClient, serviceSid string, identity string, roleSid string) (*IPUser, error) {
 	var user *IPUser
 
 	params := url.Values{}
 	params.Set("Identity", identity)
 	params.Set("RoleSid", roleSid)
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Users.json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Users.json")
 
 	if err != nil {
 		return user, err
@@ -46,10 +46,10 @@ func NewIPUser(client Client, serviceSid string, identity string, roleSid string
 }
 
 // GetIPUser returns information on the specified user.
-func GetIPUser(client Client, serviceSid, sid string) (*IPUser, error) {
+func GetIPUser(client *TwilioIPMessagingClient, serviceSid, sid string) (*IPUser, error) {
 	var user *IPUser
 
-	res, err := client.getIP(url.Values{}, "/Services/"+serviceSid+"/Users/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Services/"+serviceSid+"/Users/"+sid+".json")
 
 	if err != nil {
 		return nil, err
@@ -62,19 +62,19 @@ func GetIPUser(client Client, serviceSid, sid string) (*IPUser, error) {
 }
 
 // DeleteIPUser deletes the given IP user.
-func DeleteIPUser(client Client, serviceSid, sid string) error {
-	return client.deleteIP("/Services/" + serviceSid + "/Users/" + sid)
+func DeleteIPUser(client *TwilioIPMessagingClient, serviceSid, sid string) error {
+	return client.delete("/Services/" + serviceSid + "/Users/" + sid)
 }
 
 // UpdateIPUser updates an existing IP Messaging user.
-func UpdateIPUser(client Client, serviceSid string, sid string, identity string, roleSid string) (*IPUser, error) {
+func UpdateIPUser(client *TwilioIPMessagingClient, serviceSid string, sid string, identity string, roleSid string) (*IPUser, error) {
 	var user *IPUser
 
 	params := url.Values{}
 	params.Set("Identity", identity)
 	params.Set("RoleSid", roleSid)
 
-	res, err := client.postIP(params, "/Services/"+serviceSid+"/Users/"+sid+".json")
+	res, err := client.post(params, "/Services/"+serviceSid+"/Users/"+sid+".json")
 
 	if err != nil {
 		return user, err
@@ -87,10 +87,10 @@ func UpdateIPUser(client Client, serviceSid string, sid string, identity string,
 }
 
 // ListIPUsers returns the first page of users.
-func ListIPUsers(client Client, serviceSid string) (*IPUserList, error) {
+func ListIPUsers(client *TwilioIPMessagingClient, serviceSid string) (*IPUserList, error) {
 	var userList *IPUserList
 
-	body, err := client.getIP(nil, "/Services/"+serviceSid+"/Users.json")
+	body, err := client.get(nil, "/Services/"+serviceSid+"/Users.json")
 
 	if err != nil {
 		return userList, err
@@ -167,7 +167,7 @@ func (s *IPUserList) getPage(uri string) (*IPUserList, error) {
 
 	client := s.Client
 
-	body, err := client.getIP(nil, uri)
+	body, err := client.get(nil, uri)
 
 	if err != nil {
 		return userList, err

--- a/message.go
+++ b/message.go
@@ -44,7 +44,7 @@ func NewMessage(client Client, from string, to string, content ...Optional) (*Me
 		return nil, Error{"Must have at least a Body or MediaUrl"}
 	}
 
-	res, err := client.post(params, client.RootUrl()+"/Messages.json")
+	res, err := client.post(params, "/Messages.json")
 
 	if err != nil {
 		return message, err
@@ -59,7 +59,7 @@ func NewMessage(client Client, from string, to string, content ...Optional) (*Me
 func GetMessage(client Client, sid string) (*Message, error) {
 	var message *Message
 
-	res, err := client.get(url.Values{}, client.RootUrl()+"/Messages/"+sid+".json")
+	res, err := client.get(url.Values{}, "/Messages/"+sid+".json")
 
 	if err != nil {
 		return nil, err

--- a/message_list.go
+++ b/message_list.go
@@ -31,7 +31,7 @@ func GetMessageList(client Client, optionals ...Optional) (*MessageList, error) 
 		params.Set(param, value)
 	}
 
-	body, err := client.get(params, client.RootUrl()+"/SMS/Messages.json")
+	body, err := client.get(params, "/SMS/Messages.json")
 
 	if err != nil {
 		return messageList, err

--- a/message_list.go
+++ b/message_list.go
@@ -17,7 +17,7 @@ type MessageList struct {
 	FirstPageUri    string    `json:"first_page_uri"`
 	LastPageUri     string    `json:"last_page_uri"`
 	NextPageUri     string    `json:"next_page_uri"`
-	PreviousPageUri string    `json"previous_page_uri"`
+	PreviousPageUri string    `json":previous_page_uri"`
 	Messages        []Message `json:"sms_messages"`
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -2,9 +2,10 @@ package twiliogo
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testMessage = Message{
@@ -35,7 +36,7 @@ func TestNewMessage(t *testing.T) {
 	params.Set("To", "5555555555")
 	params.Set("Body", "TestBody")
 
-	client.On("post", params, client.RootUrl()+"/Messages.json").Return(messageJson, nil)
+	client.On("post", params, "/Messages.json").Return(messageJson, nil)
 
 	message, err := NewMessage(client, "6666666666", "5555555555", Body("TestBody"))
 
@@ -51,7 +52,7 @@ func TestGetMessage(t *testing.T) {
 
 	messageJson, _ := json.Marshal(testMessage)
 
-	client.On("get", url.Values{}, client.RootUrl()+"/Messages/testsid.json").Return(messageJson, nil)
+	client.On("get", url.Values{}, "/Messages/testsid.json").Return(messageJson, nil)
 
 	message, err := GetMessage(client, "testsid")
 

--- a/mock_client.go
+++ b/mock_client.go
@@ -1,8 +1,9 @@
 package twiliogo
 
 import (
-	"github.com/stretchr/testify/mock"
 	"net/url"
+
+	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {
@@ -29,4 +30,17 @@ func (client *MockClient) get(params url.Values, uri string) ([]byte, error) {
 func (client *MockClient) post(params url.Values, uri string) ([]byte, error) {
 	args := client.Mock.Called(params, uri)
 	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (client *MockClient) getIP(params url.Values, uri string) ([]byte, error) {
+	args := client.Mock.Called(params, uri)
+	return args.Get(0).([]byte), args.Error(1)
+}
+func (client *MockClient) postIP(params url.Values, uri string) ([]byte, error) {
+	args := client.Mock.Called(params, uri)
+	return args.Get(0).([]byte), args.Error(1)
+}
+func (client *MockClient) deleteIP(uri string) error {
+	args := client.Mock.Called(nil, uri)
+	return args.Error(1)
 }

--- a/mock_client.go
+++ b/mock_client.go
@@ -32,15 +32,7 @@ func (client *MockClient) post(params url.Values, uri string) ([]byte, error) {
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (client *MockClient) getIP(params url.Values, uri string) ([]byte, error) {
-	args := client.Mock.Called(params, uri)
-	return args.Get(0).([]byte), args.Error(1)
-}
-func (client *MockClient) postIP(params url.Values, uri string) ([]byte, error) {
-	args := client.Mock.Called(params, uri)
-	return args.Get(0).([]byte), args.Error(1)
-}
-func (client *MockClient) deleteIP(uri string) error {
+func (client *MockClient) delete(uri string) error {
 	args := client.Mock.Called(nil, uri)
 	return args.Error(1)
 }


### PR DESCRIPTION
The IP Messaging beta was opened last week. This adds support for the endpoints released so far.

Due to the complexity and interactions between messages, channels, members, users, services, roles, etc., an integration test is added for IP Messaging.

(Also fixed a JSON bug for regular message lists.)