### PR TITLE
AvaliablePhoneNumber: Initial implementation

### DIFF
--- a/avaliable_phone_number.go
+++ b/avaliable_phone_number.go
@@ -1,0 +1,177 @@
+package twiliogo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+type AvaliablePhoneNumberWrapper struct {
+	URI  string          `json:"uri"`
+	Data json.RawMessage `json:"available_phone_numbers"`
+}
+
+type AvaliablePhoneNumber struct {
+	FriendlyName        string      `json:"friendly_name"`
+	PhoneNumber         string      `json:"phone_number"`
+	IsoCountry          string      `json:"iso_country"`
+	Capabilities        Capabilites `json:"capabilities"`
+	AddressRequirements string      `json:"api_version"`
+}
+
+type TollFreeAvaliablePhoneNumber AvaliablePhoneNumber
+type MobileAvaliablePhoneNumber AvaliablePhoneNumber
+
+type LocalAvaliablePhoneNumber struct {
+	*AvaliablePhoneNumber
+	Beta bool `json:"beta"`
+}
+
+type USACanadaLocalAvaliablePhoneNumber struct {
+	*LocalAvaliablePhoneNumber
+	Lata       string `json:"lata"`
+	RateCenter string `json:"rate_center"`
+	Latitude   string `json:"latitude"`
+	Longitude  string `json:"longitude"`
+	Region     string `json:"region"`
+	PostalCode string `json:"postal_code"`
+}
+
+func GetUSACanadaLocalAvailablePhoneNumbers(client Client, isoCountryCode string, optionals ...Optional) (*[]USACanadaLocalAvaliablePhoneNumber, error) {
+	var avaliablePhoneNumbers *[]USACanadaLocalAvaliablePhoneNumber
+	avaliablePhoneNumbers = new([]USACanadaLocalAvaliablePhoneNumber)
+	if isoCountryCode != "US" && isoCountryCode != "CA" {
+		return nil, fmt.Errorf("For this function, isoCountryCode must be 'US' or 'CA', for other countries use GetLocalAvailablePhoneNumbers")
+	}
+
+	params := url.Values{}
+	for _, optional := range optionals {
+		param, value := optional.GetParam()
+		params.Set(param, value)
+	}
+
+	res, err := client.get(params, "/AvailablePhoneNumbers/"+isoCountryCode+"/Local.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapper AvaliablePhoneNumberWrapper
+	if err = json.Unmarshal(res, &wrapper); err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(wrapper.Data), avaliablePhoneNumbers)
+	return avaliablePhoneNumbers, err
+}
+
+func GetLocalAvailablePhoneNumbers(client Client, isoCountryCode string, optionals ...Optional) (*[]LocalAvaliablePhoneNumber, error) {
+	var avaliablePhoneNumbers *[]LocalAvaliablePhoneNumber
+	avaliablePhoneNumbers = new([]LocalAvaliablePhoneNumber)
+
+	params := url.Values{}
+	for _, optional := range optionals {
+		param, value := optional.GetParam()
+		params.Set(param, value)
+	}
+
+	res, err := client.get(params, "/AvailablePhoneNumbers/"+isoCountryCode+"/Local.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapper AvaliablePhoneNumberWrapper
+	if err = json.Unmarshal(res, &wrapper); err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(wrapper.Data), avaliablePhoneNumbers)
+	return avaliablePhoneNumbers, err
+}
+
+func GetTollFreeAvaliablePhoneNumber(client Client, isoCountryCode string, optionals ...Optional) (*[]TollFreeAvaliablePhoneNumber, error) {
+	var avaliablePhoneNumbers *[]TollFreeAvaliablePhoneNumber
+	avaliablePhoneNumbers = new([]TollFreeAvaliablePhoneNumber)
+
+	params := url.Values{}
+	for _, optional := range optionals {
+		param, value := optional.GetParam()
+		params.Set(param, value)
+	}
+
+	res, err := client.get(params, "/AvailablePhoneNumbers/"+isoCountryCode+"/TollFree.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapper AvaliablePhoneNumberWrapper
+	if err = json.Unmarshal(res, &wrapper); err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(wrapper.Data), avaliablePhoneNumbers)
+	return avaliablePhoneNumbers, err
+}
+
+func GetMobileAvaliablePhoneNumber(client Client, isoCountryCode string, optionals ...Optional) (*[]MobileAvaliablePhoneNumber, error) {
+	var avaliablePhoneNumbers *[]MobileAvaliablePhoneNumber
+	avaliablePhoneNumbers = new([]MobileAvaliablePhoneNumber)
+
+	params := url.Values{}
+	for _, optional := range optionals {
+		param, value := optional.GetParam()
+		params.Set(param, value)
+	}
+
+	res, err := client.get(params, "/AvailablePhoneNumbers/"+isoCountryCode+"/Mobile.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapper AvaliablePhoneNumberWrapper
+	if err = json.Unmarshal(res, &wrapper); err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(wrapper.Data), avaliablePhoneNumbers)
+	return avaliablePhoneNumbers, err
+}
+
+// type AvailablePhoneNumberTypes struct {
+// 	Local    bool
+// 	TollFree bool
+// 	Mobile   bool
+// }
+//
+// type AvaliablePhoneNumberCountryList struct {
+// 	Client          Client
+// 	Start           int                   `json:"start"`
+// 	End             int                   `json:"end"`
+// 	Page            int                   `json:"page"`
+// 	PageSize        int                   `json:"page_size"`
+// 	Uri             string                `json:"uri"`
+// 	FirstPageUri    string                `json:"first_page_uri"`
+// 	PreviousPageUri string                `json"previous_page_uri"`
+// 	NextPageUri     string                `json:"next_page_uri"`
+// 	Countries       []IncomingPhoneNumber `json:"countries"`
+// }
+//
+// type AvailablePhoneNumberCountries struct {
+// 	Country         string `json:"country"`
+// 	CountryCode     string `json:"country_code"`
+// 	Beta            bool   `json:"beta"`
+// 	AvaliableTypes  AvailablePhoneNumberTypes
+// 	SubresourceURIs map[string]interface{} `json:"subresource_uris"`
+// }
+//
+// func GetAvailablePhoneNumberCountries(client Client, beta Optional) ([]AvailablePhoneNumberCountries, err) {
+// 	var list AvaliablePhoneNumberCountryList
+// 	var avaliablePhoneNumberCountries []AvailablePhoneNumberCountries
+//
+// 	params := url.Values{}
+// 	if beta != nil {
+// 		param, value := beta.GetParam()
+// 		params.Set(param, value)
+// 	}
+// 	res, err := client.get(params, "/AvailablePhoneNumbers.json")
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	err = json.Unmarshal(res, &list)
+// }

--- a/client.go
+++ b/client.go
@@ -73,14 +73,12 @@ func (client *TwilioClient) post(values url.Values, uri string) ([]byte, error) 
 }
 
 func (client *TwilioClient) get(queryParams url.Values, uri string) ([]byte, error) {
-	var params *strings.Reader
-
 	if queryParams == nil {
 		queryParams = url.Values{}
 	}
 
-	params = strings.NewReader(queryParams.Encode())
-	req, err := http.NewRequest("GET", client.buildUri(uri), params)
+	req, err := http.NewRequest("GET", client.buildUri(uri), nil)
+	req.URL.RawQuery = queryParams.Encode()
 
 	if err != nil {
 		return nil, err

--- a/optionals.go
+++ b/optionals.go
@@ -1,5 +1,10 @@
 package twiliogo
 
+import (
+	"fmt"
+	"strconv"
+)
+
 type Optional interface {
 	GetParam() (string, string)
 }
@@ -134,4 +139,101 @@ type AreaCode string
 
 func (areaCode AreaCode) GetParam() (string, string) {
 	return "AreaCode", string(areaCode)
+}
+
+//For AvaliablePhoneNumbers
+type Contains string
+
+func (contains Contains) GetParam() (string, string) {
+	return "Contains", string(contains)
+}
+
+type SmsEnabled bool
+
+func (smsEnabled SmsEnabled) GetParam() (string, string) {
+	return "SmsEnabled", strconv.FormatBool(bool(smsEnabled))
+}
+
+type MmsEnabled bool
+
+func (mmsEnabled MmsEnabled) GetParam() (string, string) {
+	return "MmsEnabled", strconv.FormatBool(bool(mmsEnabled))
+}
+
+type VoiceEnabled bool
+
+func (voiceEnabled VoiceEnabled) GetParam() (string, string) {
+	return "VoiceEnabled", strconv.FormatBool(bool(voiceEnabled))
+}
+
+type ExcludeAllAddressRequired bool
+
+func (excludeAllAddressRequired ExcludeAllAddressRequired) GetParam() (string, string) {
+	return "ExcludeAllAddressRequired", strconv.FormatBool(bool(excludeAllAddressRequired))
+}
+
+type ExcludeLocalAddressRequired bool
+
+func (excludeLocalAddressRequired ExcludeLocalAddressRequired) GetParam() (string, string) {
+	return "ExcludeLocalAddressRequired", strconv.FormatBool(bool(excludeLocalAddressRequired))
+}
+
+type ExcludeForiegnAddressRequired bool
+
+func (excludeForiegnAddressRequired ExcludeForiegnAddressRequired) GetParam() (string, string) {
+	return "ExcludeForiegnAddressRequired", strconv.FormatBool(bool(excludeForiegnAddressRequired))
+}
+
+type Beta bool
+
+func (beta Beta) GetParam() (string, string) {
+	return "Beta", strconv.FormatBool(bool(beta))
+}
+
+type NearNumber string
+
+func (nearNumber NearNumber) GetParam() (string, string) {
+	return "NearNumber", string(nearNumber)
+}
+
+type NearLatLong struct {
+	Latitude  float64
+	Longitude float64
+}
+
+func (nearLatLong NearLatLong) GetParam() (string, string) {
+	return "NearLatLong", fmt.Sprintf("%.5f,%.5f",
+		nearLatLong.Latitude,
+		nearLatLong.Longitude,
+	)
+}
+
+type Distance uint16
+
+func (distance Distance) GetParam() (string, string) {
+	return "Distance", fmt.Sprintf("%d", distance)
+}
+
+type InPostalCode string
+
+func (inPostalCode InPostalCode) GetParam() (string, string) {
+	return "InPostalCode", string(inPostalCode)
+}
+
+type InRegion string
+
+func (inRegion InRegion) GetParam() (string, string) {
+	return "InRegion", string(inRegion)
+}
+
+type InRateCenter string
+
+func (inRateCenter InRateCenter) GetParam() (string, string) {
+	return "InRateCenter", string(inRateCenter)
+}
+
+type InLata string
+
+func (inLata InLata) GetParam() (string, string) {
+	return "InLata", string(inLata)
 }


### PR DESCRIPTION
Per documentation here: https://www.twilio.com/docs/api/rest/available-phone-numbers

Mighta gone a little sub-type crazy, but I didn't want too many nulled fields around

Obviously no unit tests here (at least yet) but I have done manual testing on `GetUSACanadaLocalAvailablePhoneNumbers()` and the others are implemented ~identically

I don't treat an empty return as an error condition, but maybe I should?

I started to implement the Countries endpoint but didn't want to deal with paging (especially because the result for my account is just one page), so I left that in here commented out
