### PR TITLE
Add option to pass in custom http client

### DIFF
--- a/ip_client.go
+++ b/ip_client.go
@@ -1,5 +1,7 @@
 package twiliogo
 
+import "net/http"
+
 // Constants for the IP Messaging service.
 const (
 	IP_MESSAGING_ROOT     = "https://ip-messaging.twilio.com"
@@ -17,5 +19,13 @@ var _ Client = &TwilioIPMessagingClient{}
 // NewIPMessagingClient creates a new Twilio IP Messaging client.
 func NewIPMessagingClient(accountSid, authToken string) *TwilioIPMessagingClient {
 	rootUrl := IP_MESSAGING_ROOT + "/" + IP_MESSAGING_VERSION
-	return &TwilioIPMessagingClient{TwilioClient{accountSid, authToken, rootUrl}}
+	return &TwilioIPMessagingClient{TwilioClient{
+		accountSid: accountSid,
+		authToken:  authToken,
+		rootUrl:    rootUrl,
+		options: options{
+			httpClient: http.DefaultClient,
+		},
+	},
+	}
 }


### PR DESCRIPTION
I choose the [functional options](http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) pattern as it is a non-breaking change for the API contract. 

Regarding tests, I am not able to get the functional tests TestIntegrationCallListNextPage or TestIntegrationMessageListNextPage to pass, even in master. I am not sure if this is something to do with our current Twilio configuration or a current issue. 
